### PR TITLE
Fix building osgWorks against old OSG 2.8.x releases

### DIFF
--- a/include/osgwTools/FBOUtils.h
+++ b/include/osgwTools/FBOUtils.h
@@ -23,7 +23,7 @@
 
 
 #include <osg/Version>
-#include "osgwTools/Export.h"
+#include <osgwTools/Version.h>
 #include <osg/FrameBufferObject>
 
 
@@ -40,6 +40,12 @@ OSG versions.
 */
 /*@{*/
 
+// Version in which OSG removed "EXT" off of FBO commands.
+// (E.g., "glGenFramebuffersEXT" became "glGenFramebuffers".
+#define OSG_FBO_CHANGE_VERSION 20906
+// Version in which OSG moved FBO commands from osg::FBOExtensions object
+// to osg::GLExtensions object, and removed FBOExtensions object altogether.
+#define OSG_FBO_CHANGE_2_VERSION 30303
 
 #ifndef GL_FRAMEBUFFER
 #  define GL_FRAMEBUFFER 0x8D40

--- a/src/osgwTools/FBOUtils.cpp
+++ b/src/osgwTools/FBOUtils.cpp
@@ -19,21 +19,11 @@
  *************** <auto-copyright.pl END do not edit this line> ***************/
 
 #include <osgwTools/FBOUtils.h>
-#include <osgwTools/Version.h>
 #include <osg/FrameBufferObject>
 
 
 namespace osgwTools
 {
-
-
-// Version in which OSG removed "EXT" off of FBO commands.
-// (E.g., "glGenFramebuffersEXT" became "glGenFramebuffers".
-#define OSG_FBO_CHANGE_VERSION 20906
-// Version in which OSG moved FBO commands from osg::FBOExtensions object
-// to osg::GLExtensions object, and removed FBOExtensions object altogether.
-#define OSG_FBO_CHANGE_2_VERSION 30303
-
 
 #if( OSGWORKS_OSG_VERSION >= OSG_FBO_CHANGE_2_VERSION )
 GLvoid glGenFramebuffers( osg::GLExtensions* fboExt, GLsizei n, GLuint* framebuffer )


### PR DESCRIPTION
Move the `OSG_FBO_CHANGE_VERSION` and `OSG_FBO_CHANGE_2_VERSION` preprocessor
`#define`s into `FBOUtils.h` so that this preprocessor comparison:

`#if( OSGWORKS_OSG_VERSION >= OSG_FBO_CHANGE_2_VERSION )`

in `FBOUtils.h` evaluates correctly.