### PR TITLE
Fix build with OpenSceneGraph >=3.5.6

### DIFF
--- a/src/osgwTools/GeometryModifier.cpp
+++ b/src/osgwTools/GeometryModifier.cpp
@@ -61,7 +61,13 @@ GeometryModifier::apply( osg::Geode& geode )
     {
         osgUtil::Optimizer::MergeGeometryVisitor mgv;
         mgv.setTargetMaximumNumberOfVertices(1000000);
+
+        // https://github.com/openscenegraph/OpenSceneGraph/commit/e0f7d3241af56751fa8e70922c1a17511aeb16cc
+        #if( OSGWORKS_OSG_VERSION >= 30506 )
+        mgv.mergeGroup(geode);
+        #else
         mgv.mergeGeode(geode);
+        #endif
     }
 
     for(unsigned int i=0;i<geode.getNumDrawables();++i)

--- a/src/osgwTools/Orientation.cpp
+++ b/src/osgwTools/Orientation.cpp
@@ -169,14 +169,12 @@ void Orientation::makeMatrix( osg::Matrix& result, const double yaw, const doubl
 
 osg::Vec3d Orientation::getYPR( const osg::Quat& q ) const
 {
-    osg::Matrix m;
-    m.set( q );
+    osg::Matrix m(q);
     return( getYPR( m ) );
 }
 void Orientation::getYPR( const osg::Quat& q, double& yaw, double& pitch, double& roll ) const
 {
-    osg::Matrix m;
-    m.set( q );
+    osg::Matrix m(q);
     getYPR( m, yaw, pitch, roll );
 }
 osg::Vec3d Orientation::getYPR( const osg::Matrix& m ) const


### PR DESCRIPTION
This is an improved version of #57. This patch is more specific about the version where `mergeGeode` was renamed to `mergeGroup` and it doesn't include version conditionals for the `Matrix` changes because the `Matrix(Quat&)` constructor was [introduced in OSG 0.9.6](https://github.com/openscenegraph/OpenSceneGraph/commit/5b93250eb03987b5444fa1b362697d9225501cb9#diff-734f762075b37998af3a6dffb62692beR40), which was released in 2003.

This has been tested with OSG 3.6.4.